### PR TITLE
Add better error handling if cfn-lint is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ For example if there is an image subfolder under your extension project workspac
 
 ## Requirements
 
-Requires cfn-lint to be installed.  `pip install cfn-lint`
+Requires cfn-lint to be installed: `pip install cfn-lint`
+
+For more information about cfn-lint can be found [here](https://github.com/awslabs/cfn-python-lint)
 
 ## Extension Settings
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example if there is an image subfolder under your extension project workspac
 
 Requires cfn-lint to be installed: `pip install cfn-lint`
 
-For more information about cfn-lint can be found [here](https://github.com/awslabs/cfn-python-lint)
+More information about cfn-lint can be found [here](https://github.com/awslabs/cfn-python-lint)
 
 ## Extension Settings
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -165,6 +165,21 @@ function validateCloudFormationFile(document: TextDocument): void {
 		let start = 0;
 		let end = Number.MAX_VALUE;
 
+		child.on('error', function(err) {
+			let errorMessage = `Unable to start cfn-lint (${err}). Is cfn-lint installed correctly?`;
+			connection.console.log(errorMessage);
+			let lineNumber = 0;
+			let diagnostic: Diagnostic = {
+				range: {
+					start: { line: lineNumber, character: start },
+					end: { line: lineNumber, character: end }
+				},
+				severity: DiagnosticSeverity.Error,
+				message: errorMessage
+			};
+			diagnostics.push(diagnostic);
+		});
+
 		child.stderr.on("data", (data: Buffer) => {
 			let err = data.toString();
 			connection.console.log(err);


### PR DESCRIPTION
*Issue https://github.com/awslabs/aws-cfn-lint-visual-studio-code/issues/9*

Added a handler to catch basically all "errors". This mainly resolved the issue that an unable error message is thrown when cfn-lint is not installed correctly.

The error is outputted as "linter output", type "Error" so it's handled as normal linting result (line/column 0). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
