### PR TITLE
Feature/better template finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cfn-lint",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cfn-lint",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "CloudFormation linter",
     "author": "Kevin DeJong",
     "license": "Apache-2.0",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "kddejong",
     "engines": {
         "vscode": "^1.18.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "CloudFormation linter",
     "author": "Kevin DeJong",
     "license": "Apache-2.0",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "kddejong",
     "engines": {
         "vscode": "^1.18.0"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #20

*Description of changes:*
Add additional logic to see if a file is a CloudFormation template.  Start looking for `Resources` and `Type` with `(AWS|Custom)` types for determining if a file is a CloudFormation template. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
