### PR TITLE
Add Rule ID and cfn-lint to error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cfn-lint",
-	"version": "0.2.4",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-cfn-lint",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "CloudFormation linter",
     "author": "Kevin DeJong",
     "license": "Apache-2.0",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "publisher": "kddejong",
     "engines": {
         "vscode": "^1.18.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "CloudFormation linter",
     "author": "Kevin DeJong",
     "license": "Apache-2.0",
-    "version": "0.2.4",
+    "version": "0.3.0",
     "publisher": "kddejong",
     "engines": {
         "vscode": "^1.18.0"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -180,7 +180,7 @@ function validateCloudFormationFile(document: TextDocument): void {
 					end: { line: lineNumber, character: end }
 				},
 				severity: DiagnosticSeverity.Error,
-				message: errorMessage
+				message: '[cfn-lint] ' + errorMessage
 			};
 			diagnostics.push(diagnostic);
 		});
@@ -195,7 +195,7 @@ function validateCloudFormationFile(document: TextDocument): void {
 					end: { line: lineNumber, character: end }
 				},
 				severity: DiagnosticSeverity.Warning,
-				message: err
+				message: '[cfn-lint] ' + err
 			};
 			diagnostics.push(diagnostic);
 		});
@@ -221,7 +221,7 @@ function validateCloudFormationFile(document: TextDocument): void {
 						end: { line: lineNumberEnd, character: columnNumberEnd }
 					},
 					severity: convertSeverity(element.Level),
-					message: element.Message
+					message: '[cfn-lint] ' + element.Rule.Id + ':' + element.Message
 				};
 
 				diagnostics.push(diagnostic);


### PR DESCRIPTION
*Issue #, if available:*
Fix #34 
*Description of changes:*
- Change output of error messages to be `[cfn-lint] E0000:Message from rule`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
