### PR TITLE
Handle Informational rules as Information

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -96,7 +96,7 @@ function convertSeverity(mistakeType: string): DiagnosticSeverity {
 	switch (mistakeType) {
 		case "Warning":
 			return DiagnosticSeverity.Warning;
-		case "Information":
+		case "Informational":
 			return DiagnosticSeverity.Information;
 		case "Hint":
 			return DiagnosticSeverity.Hint;


### PR DESCRIPTION
The linter now has rules with a severity level of "Informational". Map these correctly to Informational level.

See: https://github.com/awslabs/cfn-python-lint/blob/master/src/cfnlint/formatters/__init__.py#L56

FYI:
Not changing the String output in the linter because every IDE have different linter severities. Atom calls has `Info` ([Source](https://github.com/steelbrain/linter/blob/master/lib/validate/index.js#L7)) and Sublime does not know about Information level warnings at all ([Source](https://github.com/SublimeLinter/SublimeLinter/issues/1475))


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
