### PR TITLE
Enable LSP communication via stdio

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
                 }
             }
         }
-    }
+    },
+	"bin": {
+		"cfn-lsp": "./server/out/server.js"
+	}
 }

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
 		"node": "*"
 	},
 	"dependencies": {
+		"commander": "^3.0.0",
 		"vscode-languageserver": "^5.2.1",
 		"vscode-uri": "^2.0.0"
 	},

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
 Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
@@ -14,6 +15,8 @@ permissions and limitations under the License.
 */
 'use strict';
 
+import { Command } from 'commander';
+
 import {
 	IPCMessageReader, IPCMessageWriter, createConnection, IConnection, TextDocuments, TextDocument,
 	Diagnostic, DiagnosticSeverity, InitializeResult
@@ -23,8 +26,19 @@ import { URI } from 'vscode-uri';
 
 import { spawn } from "child_process";
 
-// Create a connection for the server. The connection uses Node's IPC as a transport
-let connection: IConnection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
+const program = new Command('cfn-lsp')
+	.allowUnknownOption()
+	.version(require('../../package.json').version)
+	.option('--stdio', 'use stdio')
+	.option('--node-ipc', 'use node-ipc')
+	.parse(process.argv);
+
+var connection: IConnection;
+if (program.stdio) {
+	connection = createConnection(process.stdin, process.stdout);
+} else {
+	connection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
+}
 
 // Create a simple text document manager. The text document manager
 // supports full document sync only

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,7 +49,7 @@ connection.onInitialize((params): InitializeResult => {
 // The content of a CloudFormation document has saved. This event is emitted
 // when the document get saved
 documents.onDidSave((event) => {
-	console.log('Running cfn-lint...');
+	connection.console.log('Running cfn-lint...');
 	validateCloudFormationFile(event.document);
 });
 
@@ -79,9 +79,9 @@ let OverrideSpecPath: string;
 
 // The settings have changed. Is send on server activation as well.
 connection.onDidChangeConfiguration((change) => {
-	console.log('Settings have been updated...');
+	connection.console.log('Settings have been updated...');
 	let settings = <Settings>change.settings;
-	console.log('Settings: ' + JSON.stringify(settings));
+	connection.console.log('Settings: ' + JSON.stringify(settings));
 
 	Path = settings.cfnLint.path || 'cfn-lint';
 	IgnoreRules = settings.cfnLint.ignoreRules;
@@ -216,7 +216,7 @@ function validateCloudFormationFile(document: TextDocument): void {
 		});
 
 		child.on('exit', function (code, signal) {
-			console.log('child process exited with ' +
+			connection.console.log('child process exited with ' +
 						`code ${code} and signal ${signal}`);
 			let tmp = stdout.toString();
 			let obj = JSON.parse(tmp);


### PR DESCRIPTION
*Issue #, if available:*
See #47.

*Description of changes:*
A crude implementation of communication with the LSP via stdio.

With this MR, and the following configuration for [vim-lsp](https://github.com/prabirshrestha/vim-lsp):
```viml
if executable('cfn-lsp')
    au User lsp_setup call lsp#register_server({
        \ 'name': 'aws-cfn-lint-languageserver',
        \ 'cmd': {server_info->[&shell, &shellcmdflag, 'cfn-lsp --stdio']},
        \ 'whitelist': ['yml', 'yaml'],
        \ 'workspace_config': { "cfnLint": {"path": "cfn-lint", "ignoreRules": [], "appendRules": [], "overrideSpecPath": ""} }
        \ })
endif
```
![image](https://user-images.githubusercontent.com/206176/63146403-2ef7ae00-c03e-11e9-86a4-ba06a898ea85.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

