### PR TITLE
Adjusting format of output message

### DIFF
--- a/client/src/test/cfnlint.test.ts
+++ b/client/src/test/cfnlint.test.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import * as assert from 'assert';
 import { getDocUri, activate } from './helper';
 
-describe('Should have failuers with a bad template', () => {
+describe('Should have failures with a bad template', () => {
 	const docUri = getDocUri('bad.yaml');
 
 	it('Diagnoses bad template', async () => {
@@ -94,7 +94,7 @@ describe('Should not have failures a non CloudFormation Template', () => {
 	});
 });
 
-describe('Should have failuers even though AWSTemplateFormatVersion isn\'t in the file', () => {
+describe('Should have failures even though AWSTemplateFormatVersion isn\'t in the file', () => {
 	const docUri = getDocUri('still_a_template.yaml');
 
 	it('Diagnoses a bad template without AWSTemplateFormatVersion', async () => {
@@ -108,7 +108,7 @@ describe('Should have failuers even though AWSTemplateFormatVersion isn\'t in th
 	});
 });
 
-describe('Should have failuers even with a space in the filename', () => {
+describe('Should have failures even with a space in the filename', () => {
 	const docUri = getDocUri('a template.yaml');
 
 	it('Diagnoses a bad template with spaces in the name', async () => {

--- a/client/src/test/cfnlint.test.ts
+++ b/client/src/test/cfnlint.test.ts
@@ -10,68 +10,68 @@ describe('Should have failuers with a bad template', () => {
 		await testDiagnostics(docUri, [
 			{
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E1001:Top level item Errors isn\'t valid',
+				message: '[cfn-lint] E1001: Top level item Errors isn\'t valid',
 				range: toRange(2, 0, 2, 6)
 			},
 			{
 				severity: vscode.DiagnosticSeverity.Warning,
-				message: '[cfn-lint] W2001:Parameter myParam not used.',
+				message: '[cfn-lint] W2001: Parameter myParam not used.',
 				range: toRange(5, 2, 5, 9)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3001:Invalid or unsupported Type AWS::EC2::Instance1 for resource MyEC2Instance1 in us-east-1',
+				message: '[cfn-lint] E3001: Invalid or unsupported Type AWS::EC2::Instance1 for resource MyEC2Instance1 in us-east-1',
 				range: toRange(12, 4, 12, 8)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3012:Property Resources/MyEC2Instance/Properties/KeyName should be of type String',
+				message: '[cfn-lint] E3012: Property Resources/MyEC2Instance/Properties/KeyName should be of type String',
 				range: toRange(20, 6, 20, 13)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3002:Invalid Property Resources/MyEC2Instance/Properties/FakeKey',
+				message: '[cfn-lint] E3002: Invalid Property Resources/MyEC2Instance/Properties/FakeKey',
 				range: toRange(21, 6, 21, 13)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E1012:Ref pIops not found as a resource or parameter',
+				message: '[cfn-lint] E1012: Ref pIops not found as a resource or parameter',
 				range: toRange(27, 12, 27, 16)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3002:Invalid Property Resources/MyEC2Instance/Properties/BlockDeviceMappings/0/Ebs/BadSubX2Key',
+				message: '[cfn-lint] E3002: Invalid Property Resources/MyEC2Instance/Properties/BlockDeviceMappings/0/Ebs/BadSubX2Key',
 				range: toRange(30, 12, 30, 23)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3002:Invalid Property Resources/MyEC2Instance/Properties/NetworkInterfaces/0/BadKey',
+				message: '[cfn-lint] E3002: Invalid Property Resources/MyEC2Instance/Properties/NetworkInterfaces/0/BadKey',
 				range: toRange(33, 10, 33, 16)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3003:Property PolicyDocument missing at Resources/RootRole/Properties/Policies/0',
+				message: '[cfn-lint] E3003: Property PolicyDocument missing at Resources/RootRole/Properties/Policies/0',
 				range: toRange(51, 10, 59, 2)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3002:Invalid Property Resources/RootRole/Properties/Policies/0/PolicyDocument1',
+				message: '[cfn-lint] E3002: Invalid Property Resources/RootRole/Properties/Policies/0/PolicyDocument1',
 				range: toRange(52, 10, 52, 25)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E1012:Ref WebServerPort not found as a resource or parameter',
+				message: '[cfn-lint] E1012: Ref WebServerPort not found as a resource or parameter',
 				range: toRange(91, 8, 91, 20)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3002:Invalid Property Resources/ElasticLoadBalancer/Properties/HealthCheck/FakeKey',
+				message: '[cfn-lint] E3002: Invalid Property Resources/ElasticLoadBalancer/Properties/HealthCheck/FakeKey',
 				range: toRange(95, 8, 95, 15)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E1012:Ref WebServerPort not found as a resource or parameter',
+				message: '[cfn-lint] E1012: Ref WebServerPort not found as a resource or parameter',
 				range: toRange(100, 14, 101, 12)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3012:Property Resources/ElasticLoadBalancer/Properties/HealthCheck/UnhealthyThreshold should be of type String',
+				message: '[cfn-lint] E3012: Property Resources/ElasticLoadBalancer/Properties/HealthCheck/UnhealthyThreshold should be of type String',
 				range: toRange(104, 8, 104, 26)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3012:Property Resources/ElasticLoadBalancer/Properties/HealthCheck/Interval should be of type String',
+				message: '[cfn-lint] E3012: Property Resources/ElasticLoadBalancer/Properties/HealthCheck/Interval should be of type String',
 				range: toRange(106, 8, 106, 16)
 			}, {
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E1010:Invalid GetAtt ElasticLoadBalancer.DNE for resource myErrorOutput',
+				message: '[cfn-lint] E1010: Invalid GetAtt ElasticLoadBalancer.DNE for resource myErrorOutput',
 				range: toRange(112, 4, 112, 9)
 			}
 		]);
@@ -101,7 +101,7 @@ describe('Should have failuers even though AWSTemplateFormatVersion isn\'t in th
 		await testDiagnostics(docUri, [
 			{
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3002:Invalid Property Resources/RootRole/Properties/BadKey',
+				message: '[cfn-lint] E3002: Invalid Property Resources/RootRole/Properties/BadKey',
 				range: toRange(5, 6, 5, 12)
 			}
 		]);
@@ -115,7 +115,7 @@ describe('Should have failuers even with a space in the filename', () => {
 		await testDiagnostics(docUri, [
 			{
 				severity: vscode.DiagnosticSeverity.Error,
-				message: '[cfn-lint] E3002:Invalid Property Resources/RootRole/Properties/BadKey',
+				message: '[cfn-lint] E3002: Invalid Property Resources/RootRole/Properties/BadKey',
 				range: toRange(5, 6, 5, 12)
 			}
 		]);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -245,7 +245,7 @@ function validateCloudFormationFile(document: TextDocument): void {
 						end: { line: lineNumberEnd, character: columnNumberEnd }
 					},
 					severity: convertSeverity(element.Level),
-					message: '[cfn-lint] ' + element.Rule.Id + ':' + element.Message
+					message: '[cfn-lint] ' + element.Rule.Id + ': ' + element.Message
 				};
 
 				diagnostics.push(diagnostic);


### PR DESCRIPTION
*Description of changes:*

Added space between the rule id and message in the finding output to provide cleaner separation of elements and improve readability.

Before:
![cfn-lint-output](https://user-images.githubusercontent.com/48760600/66669451-2de99400-ec1d-11e9-8d70-11b93c6b2369.png)

After:
![cfn-lint-output-space](https://user-images.githubusercontent.com/48760600/66669491-42c62780-ec1d-11e9-81fd-faec942fdbfa.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
